### PR TITLE
Avoid looking for Curses and Termcap if Readline is found

### DIFF
--- a/recipe/CMakeLists.patch
+++ b/recipe/CMakeLists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3f1e41d5..abb86745 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -329,8 +329,6 @@ if(READLINE_FOUND)
+     # define for src/oc/hoc.c
+     set(DEF_RL_GETC_FUNCTION use_rl_getc_function)
+   endif()
+-  find_package(Curses QUIET)
+-  find_package(Termcap QUIET)
+ else()
+   find_package(Curses REQUIRED QUIET)
+   add_subdirectory(src/readline)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
     patches:
       - avoid-basename-s.patch  # [linux]
       - x-sentinel.patch
+      - CMakeLists.patch  # [osx]
 
 build:
   number: {{ build }}


### PR DESCRIPTION
This PR *may* fix some issues with the macos builds linking Curses provided by Xcode during the cmake configuration, and not ncurses which is linked by readline. 